### PR TITLE
Update ImageScreen.js

### DIFF
--- a/packages/bappo-components/storybook/storybook-native/storybook/stories/1-primitives/Image/ImageScreen.js
+++ b/packages/bappo-components/storybook/storybook-native/storybook/stories/1-primitives/Image/ImageScreen.js
@@ -33,7 +33,15 @@ const ImageScreen = () => (
         }}
       />
 
-      <DocItem name="style" typeInfo="?style" />
+      <DocItem 
+      name="style" 
+      typeInfo="?style" 
+      description={
+          <AppText>
+            If no style is applied, the height defaults to 0 and the image will remain invisible.
+          </AppText>
+
+      />
     </Section>
 
     <Section title="Example">


### PR DESCRIPTION
Added following comment to style information.

"If no style is applied, the height defaults to 0 and the image will remain invisible."