### PR TITLE
Add prop `placement` to Popover

### DIFF
--- a/packages/bappo-components/src/internals/Popover.web/types.ts
+++ b/packages/bappo-components/src/internals/Popover.web/types.ts
@@ -3,5 +3,28 @@ export type PopoverProps = {
   children?: React.ReactNode;
   onContentMouseDown?: (event: React.MouseEvent) => void;
   onRequestClose: () => void;
+  /**
+   * Note: please make sure you wrap a `React.useCallback` if you pass an inline
+   * function.
+   *
+   * Callack function to customize the position of the popup. It is called with
+   * the position of the anchor element and the popup content and must return
+   * the top and left of the popup, relative to the window. If the popup is
+   * obscured by a screen edge, it is then repositioned to align the the screen
+   * edge.
+   *
+   * Default placement is top = anchorRect.top and left = anchorRect.left (the
+   * left edge of the popup aligns with the left edge of the anchor and the top
+   * edge of the popup aligns with the top edge of the anchor).
+   */
+  placement?: GetPopupPosition;
   visible?: boolean;
+};
+
+export type GetPopupPosition = (
+  anchorRect: DOMRect,
+  popupContentRect: DOMRect,
+) => {
+  top: number;
+  left: number;
 };


### PR DESCRIPTION
This PR adds a prop `placement` to Popover so that you can customize the position of the popup.

It is a callback that is called with the anchor and popup position which gives you full control without having to measure. Then in the future we could allow using strings for some common configurations, e.g. `placement="bottom"` for showing the popup below the anchor.