### PR TITLE
Fix broken VirtualizedList due to changes in ScrollView

### DIFF
--- a/packages/bappo-components/src/internals/web/ScrollViewBase.tsx
+++ b/packages/bappo-components/src/internals/web/ScrollViewBase.tsx
@@ -1,0 +1,119 @@
+import throttle from 'lodash/throttle';
+import * as React from 'react';
+import styled from 'styled-components';
+
+import { ViewLayoutEvent } from '../../events';
+import { ScrollViewProps } from '../../primitives/ScrollView/types';
+import { DivViewBase } from './ViewBase';
+
+type Props = ScrollViewProps & {
+  className?: string;
+  ref?: React.Ref<HTMLDivElement>;
+};
+
+export const ScrollViewBase = React.forwardRef(
+  (
+    {
+      accessibilityLabel,
+      children,
+      className,
+      horizontal,
+      onLayout,
+      style,
+      contentContainerStyle,
+      testID,
+      onScroll,
+      onContentSizeChange,
+      scrollEventThrottle = 16,
+    }: Props,
+    ref: React.Ref<HTMLDivElement>,
+  ) => {
+    const styleProps = {
+      className,
+      $horizontal: horizontal,
+      style,
+    };
+
+    const onContentLayout = (event: ViewLayoutEvent) => {
+      const { width, height } = event.nativeEvent.layout;
+
+      onContentSizeChange && onContentSizeChange(width, height);
+    };
+
+    const _onScroll = (event: React.SyntheticEvent<HTMLDivElement>) => {
+      event.persist();
+      onScrollThrottled(event);
+    };
+
+    const onScrollThrottled = throttle(
+      (event: React.SyntheticEvent<HTMLDivElement>) => {
+        onScroll &&
+          onScroll({
+            nativeEvent: {
+              contentOffset: {
+                x: event.currentTarget.scrollLeft,
+                y: event.currentTarget.scrollTop,
+              },
+              contentSize: {
+                height: event.currentTarget.scrollHeight,
+                width: event.currentTarget.scrollWidth,
+              },
+              layoutMeasurement: {
+                height: event.currentTarget.offsetHeight,
+                width: event.currentTarget.offsetWidth,
+              },
+            },
+            timeStamp: Date.now(),
+          });
+      },
+      scrollEventThrottle,
+    );
+
+    return (
+      <ScrollContainer
+        {...styleProps}
+        accessibilityLabel={accessibilityLabel}
+        ref={ref}
+        onLayout={onLayout}
+        onScroll={_onScroll}
+        testID={testID}
+      >
+        <ContentContainer
+          $horizontal={horizontal}
+          onLayout={onContentLayout}
+          style={contentContainerStyle}
+        >
+          {children}
+        </ContentContainer>
+      </ScrollContainer>
+    );
+  },
+);
+
+const ScrollContainer = styled(DivViewBase)<{ $horizontal?: boolean }>`
+  flex: 1;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  transform: translateZ(0);
+
+  ${({ $horizontal }) =>
+    $horizontal &&
+    `
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+  `};
+`;
+
+const ContentContainer = styled(DivViewBase)<{ $horizontal?: boolean }>`
+  ${({ $horizontal }) =>
+    $horizontal
+      ? `
+    flex-direction: row;
+    min-width: 100%;
+  `
+      : `
+    min-height: 100%;
+  `};
+`;

--- a/packages/bappo-components/src/primitives/FlatList/FlatList.native.js
+++ b/packages/bappo-components/src/primitives/FlatList/FlatList.native.js
@@ -321,6 +321,7 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>> {
     }
   }
 
+  // To be able to use View inside TouchableHighlight/TouchableOpacity
   setNativeProps = (props: Object) => {
     if (this._listRef) {
       this._listRef.setNativeProps(props);

--- a/packages/bappo-components/src/primitives/FlatList/FlatList.web.js
+++ b/packages/bappo-components/src/primitives/FlatList/FlatList.web.js
@@ -460,12 +460,6 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
     }
   }
 
-  setNativeProps(props: Object) {
-    if (this._listRef) {
-      this._listRef.setNativeProps(props);
-    }
-  }
-
   UNSAFE_componentWillMount() {
     this._checkProps(this.props);
   }

--- a/packages/bappo-components/src/primitives/ScrollView/ScrollView.native.tsx
+++ b/packages/bappo-components/src/primitives/ScrollView/ScrollView.native.tsx
@@ -19,22 +19,16 @@ const ScrollView = React.forwardRef(
     }: ScrollViewProps,
     ref,
   ) => {
+    const scrollableNodeRef = React.useRef<RN.ScrollView>(null);
+
     React.useImperativeHandle(ref, () => ({
       scrollTo: (options: { x?: number; y?: number }) => {
-        scrollableNodeRef &&
-          scrollableNodeRef.current &&
-          scrollableNodeRef.current.scrollTo(options);
+        scrollableNodeRef.current?.scrollTo(options);
       },
       scrollToEnd: () => {
-        if (scrollableNodeRef && scrollableNodeRef.current) {
-          scrollableNodeRef &&
-            scrollableNodeRef.current &&
-            scrollableNodeRef.current.scrollToEnd();
-        }
+        scrollableNodeRef.current?.scrollToEnd();
       },
     }));
-
-    const scrollableNodeRef = React.useRef<RN.ScrollView>(null);
 
     const props: RN.ScrollViewProps = {
       accessibilityLabel,

--- a/packages/bappo-components/src/primitives/ScrollView/ScrollView.web.tsx
+++ b/packages/bappo-components/src/primitives/ScrollView/ScrollView.web.tsx
@@ -1,9 +1,6 @@
-import throttle from 'lodash/throttle';
 import * as React from 'react';
-import styled from 'styled-components';
 
-import { ViewLayoutEvent } from '../../events';
-import { DivViewBase } from '../../internals/web/ViewBase';
+import { ScrollViewBase } from '../../internals/web/ScrollViewBase';
 import { ScrollViewProps } from './types';
 
 type Props = ScrollViewProps & {
@@ -27,11 +24,13 @@ const ScrollView = React.forwardRef(
     }: Props,
     ref,
   ) => {
+    const scrollableNodeRef = React.useRef<HTMLDivElement>(null);
+
     React.useImperativeHandle(ref, () => ({
       scrollTo: (options: { x?: number; y?: number }) => {
         const { x, y } = options;
 
-        if (scrollableNodeRef && scrollableNodeRef.current) {
+        if (scrollableNodeRef.current) {
           if (typeof x === 'number') {
             scrollableNodeRef.current.scrollLeft = x;
           }
@@ -41,103 +40,37 @@ const ScrollView = React.forwardRef(
         }
       },
       scrollToEnd: () => {
-        if (scrollableNodeRef && scrollableNodeRef.current) {
-          scrollableNodeRef.current.scrollTop =
-            scrollableNodeRef.current.scrollHeight;
+        if (scrollableNodeRef.current) {
+          if (horizontal) {
+            scrollableNodeRef.current.scrollLeft =
+              scrollableNodeRef.current.scrollWidth;
+          } else {
+            scrollableNodeRef.current.scrollTop =
+              scrollableNodeRef.current.scrollHeight;
+          }
         }
       },
     }));
 
-    const scrollableNodeRef = React.useRef<HTMLDivElement>(null);
-
-    const styleProps = {
+    const props = {
+      accessibilityLabel,
       className,
-      $horizontal: horizontal,
-      style,
-    };
-
-    const onContentLayout = (event: ViewLayoutEvent) => {
-      const { width, height } = event.nativeEvent.layout;
-
-      onContentSizeChange && onContentSizeChange(width, height);
-    };
-
-    const _onScroll = (event: React.SyntheticEvent<HTMLDivElement>) => {
-      event.persist();
-      onScrollThrottled(event);
-    };
-
-    const onScrollThrottled = throttle(
-      (event: React.SyntheticEvent<HTMLDivElement>) => {
-        onScroll &&
-          onScroll({
-            nativeEvent: {
-              contentOffset: {
-                x: event.currentTarget.scrollLeft,
-                y: event.currentTarget.scrollTop,
-              },
-              contentSize: {
-                height: event.currentTarget.scrollHeight,
-                width: event.currentTarget.scrollWidth,
-              },
-              layoutMeasurement: {
-                height: event.currentTarget.offsetHeight,
-                width: event.currentTarget.offsetWidth,
-              },
-            },
-            timeStamp: Date.now(),
-          });
-      },
+      horizontal,
+      onContentSizeChange,
+      onLayout,
+      onScroll,
       scrollEventThrottle,
-    );
+      style,
+      contentContainerStyle,
+      testID,
+    };
 
     return (
-      <ScrollContainer
-        {...styleProps}
-        accessibilityLabel={accessibilityLabel}
-        ref={scrollableNodeRef}
-        onLayout={onLayout}
-        onScroll={_onScroll}
-        testID={testID}
-      >
-        <ContentContainer
-          $horizontal={horizontal}
-          onLayout={onContentLayout}
-          style={contentContainerStyle}
-        >
-          {children}
-        </ContentContainer>
-      </ScrollContainer>
+      <ScrollViewBase {...props} ref={scrollableNodeRef}>
+        {children}
+      </ScrollViewBase>
     );
   },
 );
 
 export default ScrollView;
-
-const ScrollContainer = styled(DivViewBase)<{ $horizontal?: boolean }>`
-  flex: 1;
-  overflow-x: hidden;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  transform: translateZ(0);
-
-  ${({ $horizontal }) =>
-    $horizontal &&
-    `
-    flex-direction: row;
-    overflow-x: auto;
-    overflow-y: hidden;
-  `};
-`;
-
-const ContentContainer = styled(DivViewBase)<{ $horizontal?: boolean }>`
-  ${({ $horizontal }) =>
-    $horizontal
-      ? `
-    flex-direction: row;
-    min-width: 100%;
-  `
-      : `
-    min-height: 100%;
-  `};
-`;


### PR DESCRIPTION
`VirtualizedList` used to use an internal class field to get the DOM node of the underlying scrollable div which is no longer available after we changed `ScrollView` from a class component to a function component. This PR fixed the issue without exposing the DOM node. This is how it's done:

1. A new internal component `ScrollViewBase` has been created which gives you the DOM node of the container through `ref`.

1. `ScrollView` uses `ScrollViewBase` under the hood and exposes only methods like `scrollTo` and `scrollToEnd` in the ref instance. DOM node is not exposed so that we have a consistent API on web and native.

1. `VirtualizedList` uses `ScrollViewBase` instead of `ScrollView` under the hood so it can get access to the DOM node.

Also fixed some logic in `VirtualizedList` that assumes the list to be vertical.