### PR TITLE
#1390 Dropdown component's default icon

### DIFF
--- a/packages/bappo-components/src/components/Card/Card.tsx
+++ b/packages/bappo-components/src/components/Card/Card.tsx
@@ -7,7 +7,7 @@ import { CardProps } from './types';
 
 export default function Card({ children, testID, ...rest }: CardProps) {
   return (
-    <StyledView selectable testID={testID} {...rest}>
+    <StyledView testID={testID} {...rest}>
       {children}
     </StyledView>
   );

--- a/packages/bappo-components/src/components/Dropdown/Dropdown.native.tsx
+++ b/packages/bappo-components/src/components/Dropdown/Dropdown.native.tsx
@@ -16,7 +16,7 @@ import { DropdownProps } from './types';
 
 export default function Dropdown({
   actions,
-  icon,
+  icon = 'menu',
   children,
   iconColor = 'black',
 }: DropdownProps) {

--- a/packages/bappo-components/src/components/Dropdown/Dropdown.native.tsx
+++ b/packages/bappo-components/src/components/Dropdown/Dropdown.native.tsx
@@ -16,7 +16,7 @@ import { DropdownProps } from './types';
 
 export default function Dropdown({
   actions,
-  icon = 'menu',
+  icon = 'more-vert',
   children,
   iconColor = 'black',
 }: DropdownProps) {

--- a/packages/bappo-components/src/components/Dropdown/Dropdown.web.tsx
+++ b/packages/bappo-components/src/components/Dropdown/Dropdown.web.tsx
@@ -20,7 +20,7 @@ type Props = DropdownProps & {
 
 export default function Dropdown({
   actions,
-  icon = 'menu',
+  icon = 'more-vert',
   align,
   width = 300,
   children,

--- a/packages/bappo-components/src/components/Dropdown/Dropdown.web.tsx
+++ b/packages/bappo-components/src/components/Dropdown/Dropdown.web.tsx
@@ -20,7 +20,7 @@ type Props = DropdownProps & {
 
 export default function Dropdown({
   actions,
-  icon,
+  icon = 'menu',
   align,
   width = 300,
   children,

--- a/packages/bappo-components/src/components/Dropdown/__tests__/index.web.tsx
+++ b/packages/bappo-components/src/components/Dropdown/__tests__/index.web.tsx
@@ -149,7 +149,7 @@ test('should render a dropdown menu icon using the default icon', () => {
   >
     <div
       class="c1 c2 c3"
-      data-text-as-pseudo-element=""
+      data-text-as-pseudo-element=""
     />
   </div>
 </div>

--- a/packages/bappo-components/src/components/Dropdown/__tests__/index.web.tsx
+++ b/packages/bappo-components/src/components/Dropdown/__tests__/index.web.tsx
@@ -23,67 +23,135 @@ test('should render a dropdown menu icon', () => {
     <Dropdown actions={actions} icon="cloud" testID="test" />,
   );
   expect(getByTestId('test')).toMatchInlineSnapshot(`
-  .c1 {
-    box-sizing: border-box;
-    color: #191E26;
-    display: inline;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    -webkit-flex-shrink: 0;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
-    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
-    font-size: 14px;
-    position: relative;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    -ms-hyphens: auto;
-    cursor: inherit;
-  }
-  
-  .c2 {
-    font-family: Material Icons;
-    font-size: 16px;
-    text-align: center;
-  }
-  
-  .c3 {
-    -webkit-flex: none;
-    -ms-flex: none;
-    flex: none;
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    -ms-flex-align: center;
-    align-items: center;
-    color: black;
-    height: 24px;
-    line-height: 24px;
-    width: 24px;
-    font-size: 16px;
-  }
-  
-  .c0 {
-    display: inline-block;
-  }
-  
-  .c0:hover {
-    opacity: 0.8;
-  }
-  
+      .c1 {
+        box-sizing: border-box;
+        color: #191E26;
+        display: inline;
+        -webkit-box-flex: 0;
+        -webkit-flex-grow: 0;
+        -ms-flex-positive: 0;
+        flex-grow: 0;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+        font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+        font-size: 14px;
+        position: relative;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        -ms-hyphens: auto;
+        cursor: inherit;
+      }
+      
+      .c2 {
+        font-family: Material Icons;
+        font-size: 16px;
+        text-align: center;
+      }
+      
+      .c3 {
+        -webkit-flex: none;
+        -ms-flex: none;
+        flex: none;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        color: black;
+        height: 24px;
+        line-height: 24px;
+        width: 24px;
+        font-size: 16px;
+      }
+      
+      .c0 {
+        display: inline-block;
+      }
+      
+      .c0:hover {
+        opacity: 0.8;
+      }
+      
+      <div
+        class="c0"
+        data-testid="test"
+      >
+        <div
+          style="display: inline-block; cursor: pointer; padding: 0px 5px;"
+        >
+          <div
+            class="c1 c2 c3"
+            data-text-as-pseudo-element=""
+          />
+        </div>
+      </div>
+    `);
+});
+
+test('should render a dropdown menu icon using the default icon', () => {
+  const { getByTestId } = render(<Dropdown actions={actions} testID="test" />);
+  expect(getByTestId('test')).toMatchInlineSnapshot(`
+.c1 {
+  box-sizing: border-box;
+  color: #191E26;
+  display: inline;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  position: relative;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  -ms-hyphens: auto;
+  cursor: inherit;
+}
+
+.c2 {
+  font-family: Material Icons;
+  font-size: 16px;
+  text-align: center;
+}
+
+.c3 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: black;
+  height: 24px;
+  line-height: 24px;
+  width: 24px;
+  font-size: 16px;
+}
+
+.c0 {
+  display: inline-block;
+}
+
+.c0:hover {
+  opacity: 0.8;
+}
+
+<div
+  class="c0"
+  data-testid="test"
+>
   <div
-    class="c0"
-    data-testid="test"
+    style="display: inline-block; cursor: pointer; padding: 0px 5px;"
   >
     <div
-      style="display: inline-block; cursor: pointer; padding: 0px 5px;"
-    >
-      <div
-        class="c1 c2 c3"
-        data-text-as-pseudo-element=""
-      />
-    </div>
+      class="c1 c2 c3"
+      data-text-as-pseudo-element=""
+    />
   </div>
-  `);
+</div>
+`);
 });

--- a/packages/bappo-components/src/components/Dropdown/types.ts
+++ b/packages/bappo-components/src/components/Dropdown/types.ts
@@ -9,7 +9,7 @@ export type ModalFormSubmitButtonProps = {
 
 export type DropdownProps = {
   actions: any;
-  icon: string;
+  icon?: string;
   children?: any;
   iconColor?: string;
   testID?: string;

--- a/packages/bappo-components/src/components/IconCard/IconCard.tsx
+++ b/packages/bappo-components/src/components/IconCard/IconCard.tsx
@@ -53,7 +53,7 @@ const Container = styled(TouchableView)`
 
 const StyledSubHeading = styled(SubHeading)``;
 
-const StyledView = styled(View)`
+const StyledView = styled(View)<{ $size: number; $color?: string }>`
   padding: 8px;
   border-radius: 3px;
   width: 100%;


### PR DESCRIPTION
- Updated Dropdown component to use the `menu` icon as the default.
- Updated IconCard's styled-component definition
- Remove selectable prop specified by Card on the View component
- Added a test for the default icon case for the Dropdown component