### PR TITLE
Improve Menu

### DIFF
--- a/packages/bappo-components/src/components/Heading/__tests__/index.web.tsx
+++ b/packages/bappo-components/src/components/Heading/__tests__/index.web.tsx
@@ -1,3 +1,6 @@
+import 'jest-styled-components';
+import 'react-testing-library/cleanup-after-each';
+
 import React from 'react';
 import { render } from 'react-testing-library';
 
@@ -10,8 +13,38 @@ test('should render a heading', () => {
     </Heading>,
   );
   expect(getByTestId('test')).toMatchInlineSnapshot(`
+    .c0 {
+      box-sizing: border-box;
+      color: #191E26;
+      display: inline;
+      -webkit-box-flex: 0;
+      -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+      flex-grow: 0;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
+      font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+      font-size: 14px;
+      position: relative;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      -ms-hyphens: auto;
+      cursor: text;
+      -webkit-user-select: text;
+      -moz-user-select: text;
+      -ms-user-select: text;
+      user-select: text;
+    }
+
+    .c1 {
+      height: 26px;
+      line-height: 26px;
+      font-size: 18px;
+    }
+
     <div
-      class="sc-AxirZ hSMBAU sc-AxiKw SDvYe"
+      class="c0 c1"
       data-testid="test"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/packages/bappo-components/src/components/IconCard/__tests__/index.web.tsx
+++ b/packages/bappo-components/src/components/IconCard/__tests__/index.web.tsx
@@ -1,3 +1,6 @@
+import 'jest-styled-components';
+import 'react-testing-library/cleanup-after-each';
+
 import React from 'react';
 import { render } from 'react-testing-library';
 
@@ -17,30 +20,256 @@ test('should render an IconCard', () => {
     />,
   );
   expect(getByTestId('test')).toMatchInlineSnapshot(`
+    .c3 {
+      -webkit-align-items: stretch;
+      -webkit-box-align: stretch;
+      -ms-flex-align: stretch;
+      align-items: stretch;
+      border-color: #191E26;
+      border-style: solid;
+      border-width: 0;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-flex: 0;
+      -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+      flex-grow: 0;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
+      position: relative;
+      min-height: 0;
+      min-width: 0;
+    }
+
+    .c0 {
+      -webkit-align-items: stretch;
+      -webkit-box-align: stretch;
+      -ms-flex-align: stretch;
+      align-items: stretch;
+      border-color: #191E26;
+      border-style: solid;
+      border-width: 0;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-flex: 0;
+      -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+      flex-grow: 0;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
+      position: relative;
+      min-height: 0;
+      min-width: 0;
+    }
+
+    .c1 {
+      -webkit-align-items: stretch;
+      -webkit-box-align: stretch;
+      -ms-flex-align: stretch;
+      align-items: stretch;
+      border-color: #191E26;
+      border-style: solid;
+      border-width: 0;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-flex: 0;
+      -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+      flex-grow: 0;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
+      position: relative;
+      min-height: 0;
+      min-width: 0;
+      background-color: transparent;
+      border-color: transparent;
+      border-width: 0;
+      padding: 0;
+      text-align: left;
+      outline: none;
+      cursor: pointer;
+    }
+
+    .c1 * {
+      cursor: pointer;
+    }
+
+    .c6 {
+      box-sizing: border-box;
+      color: #191E26;
+      display: inline;
+      -webkit-box-flex: 0;
+      -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+      flex-grow: 0;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
+      font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+      font-size: 14px;
+      position: relative;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      -ms-hyphens: auto;
+      cursor: inherit;
+    }
+
+    .c10 {
+      box-sizing: border-box;
+      color: #191E26;
+      display: inline;
+      -webkit-box-flex: 0;
+      -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+      flex-grow: 0;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
+      font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+      font-size: 14px;
+      position: relative;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      -ms-hyphens: auto;
+      cursor: text;
+      -webkit-user-select: text;
+      -moz-user-select: text;
+      -ms-user-select: text;
+      user-select: text;
+    }
+
+    .c5 {
+      padding: 2px;
+      border-radius: 20px;
+      background: #c23934;
+      position: absolute;
+      top: -5px;
+      right: -5px;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-box-pack: center;
+      -webkit-justify-content: center;
+      -ms-flex-pack: center;
+      justify-content: center;
+      min-width: 20px;
+      height: 20px;
+    }
+
+    .c7 {
+      color: white;
+      font-size: 12px;
+    }
+
+    .c8 {
+      font-family: Material Icons;
+      font-size: 16px;
+      text-align: center;
+    }
+
+    .c11 {
+      height: 24px;
+      line-height: 24px;
+      font-size: 16px;
+    }
+
+    .c2 {
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      width: 120px;
+      margin: 12px;
+    }
+
+    .c4 {
+      padding: 8px;
+      border-radius: 3px;
+      width: 100%;
+      height: 120px;
+      background: #0070D2;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-box-pack: center;
+      -webkit-justify-content: center;
+      -ms-flex-pack: center;
+      justify-content: center;
+      margin: 8px;
+    }
+
+    .c9 {
+      -webkit-flex: none;
+      -ms-flex: none;
+      flex: none;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      color: white;
+      height: 24px;
+      line-height: 24px;
+      width: 24px;
+      font-size: 16px;
+      width: 48px;
+      font-size: 40px;
+    }
+
     <div
-      class="sc-AxirZ fUDkQH TouchableViewBase__StyledViewBase-cz83lq-0 kgslKY sc-fzozJi dVClKc"
+      class="c0 c1 c2"
       data-testid="test"
       role="button"
       tabindex="0"
     >
       <div
-        class="sc-AxjAm hwdivQ Viewweb__StyledViewBase-io1hre-0 gXDTWH sc-fzpans gGGqKl"
+        class="c3 c4"
       >
         <div
-          class="sc-AxjAm hwdivQ Viewweb__StyledViewBase-io1hre-0 gXDTWH sc-AxhUy hSHeih"
+          class="c3 c5"
         >
           <div
-            class="sc-AxhCb gXTyxi sc-AxgMl bgGdbt"
+            class="c6 c7"
             data-text-as-pseudo-element="46"
           />
         </div>
         <div
-          class="sc-AxhCb gXTyxi sc-AxheI ioXmAg sc-Axmtr sc-fzplWN ewbThp"
+          class="c6 c8 sc-AxmLO c9"
           data-text-as-pseudo-element=""
         />
       </div>
       <div
-        class="sc-AxhCb eIjymE sc-AxmLO hOwDtD sc-fzoLsD fqEnxe"
+        class="c10 c11 "
       >
         Riders
       </div>

--- a/packages/bappo-components/src/components/Menu/Menu.native.tsx
+++ b/packages/bappo-components/src/components/Menu/Menu.native.tsx
@@ -1,25 +1,26 @@
 import * as React from 'react';
 
-import View from '../../primitives/View';
+import Colors from '../../apis/Colors';
 import Icon from '../Icon';
 import { Context, useMenuContext } from './MenuContext';
 // Note that this is not the Modal we export. It has a slide animation on native.
 import Modal from './Modal';
 import {
   ActionRow,
-  BackLink,
-  Label,
-  LinkContainer,
-  LinkInner,
+  MenuItemIcon,
+  MenuItemLabel,
   ModalContainer,
+  TriggerContainer,
 } from './StyledComponents.native';
 import { MenuItemProps, MenuProps } from './types';
 
 export default function Menu({
-  icon = 'menu',
   children,
-  iconColor = 'black',
+  icon = 'menu',
+  iconColor = Colors.BLACK,
+  testID,
   trigger,
+  triggerStyle,
 }: MenuProps) {
   const [active, setActive] = React.useState(false);
 
@@ -27,42 +28,42 @@ export default function Menu({
 
   return (
     <Context.Provider value={{ close, active }}>
-      <LinkContainer>
-        <LinkInner onPress={() => setActive(true)}>
-          {trigger || <Icon name={icon} color={iconColor} />}
-        </LinkInner>
-        <Modal onRequestClose={close} visible={active}>
-          <ModalContainer>
-            <BackButton onPress={close} />
-            {children}
-          </ModalContainer>
-        </Modal>
-      </LinkContainer>
+      <TriggerContainer
+        onPress={() => setActive(true)}
+        style={triggerStyle}
+        testID={testID}
+      >
+        {typeof trigger === 'function'
+          ? trigger(active)
+          : trigger || <Icon name={icon} color={iconColor} />}
+      </TriggerContainer>
+      <Modal onRequestClose={close} visible={active}>
+        <ModalContainer>{children}</ModalContainer>
+      </Modal>
     </Context.Provider>
   );
 }
 
-const BackButton = ({ onPress }) => (
-  <BackLink onPress={onPress}>
-    <View pointerEvents={'none'}>
-      <Icon name="arrow-back-ios" />
-    </View>
-  </BackLink>
-);
-
-const Item = ({ label, icon, onPress }: MenuItemProps) => {
+const Item = ({ children, icon, numberOfLines, onPress }: MenuItemProps) => {
   const context = useMenuContext();
 
   return (
     <ActionRow
-      key={label}
       onPress={() => {
         context.close();
-        onPress();
+        onPress?.();
       }}
     >
-      {icon && <Icon name={icon} />}
-      <Label>{label}</Label>
+      {typeof children === 'string' ? (
+        <React.Fragment>
+          {icon ? <MenuItemIcon name={icon} /> : null}
+          <MenuItemLabel numberOfLines={numberOfLines} $hasIcon={!!icon}>
+            {children}
+          </MenuItemLabel>
+        </React.Fragment>
+      ) : (
+        children
+      )}
     </ActionRow>
   );
 };

--- a/packages/bappo-components/src/components/Menu/MenuContext.ts
+++ b/packages/bappo-components/src/components/Menu/MenuContext.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import { MenuContext } from './types';
+export type MenuContext = {
+  close: () => void;
+  active: boolean;
+};
 
 export const Context = React.createContext<MenuContext | undefined>(undefined);
 

--- a/packages/bappo-components/src/components/Menu/StyledComponents.native.ts
+++ b/packages/bappo-components/src/components/Menu/StyledComponents.native.ts
@@ -1,8 +1,10 @@
+import { Dimensions } from 'react-native';
 import styled from 'styled-components';
 
+import ScrollView from '../../primitives/ScrollView';
 import Text from '../../primitives/Text';
 import TouchableView from '../../primitives/TouchableView';
-import View from '../../primitives/View';
+import Icon from '../Icon';
 
 export const ActionRow = styled(TouchableView)`
   flex-direction: row;
@@ -12,27 +14,21 @@ export const ActionRow = styled(TouchableView)`
   border-bottom-color: #eee;
   height: 40px;
   align-items: center;
-  padding-left: 8px;
 `;
 
-export const Label = styled(Text)`
-  padding-left: 4px;
+export const TriggerContainer = styled(TouchableView)``;
+
+export const ModalContainer = styled(ScrollView)`
+  max-height: ${Dimensions.get('window').height}px;
 `;
 
-export const LinkContainer = styled(View)`
-  width: 50px;
+export const MenuItemIcon = styled(Icon)`
+  margin-left: 8px;
 `;
 
-export const LinkInner = styled(TouchableView)`
-  width: 50px;
-`;
-
-export const ModalContainer = styled(View)``;
-
-export const BackLink = styled(TouchableView)`
-  background-color: #f8f8f8;
-  flex-direction: row;
-  height: 45px;
-  align-items: center;
-  padding-left: 8px;
+export const MenuItemLabel = styled(Text)<{
+  $hasIcon: boolean;
+}>`
+  padding-right: 8px;
+  ${({ $hasIcon }) => ($hasIcon ? '' : `padding-left: 8px;`)};
 `;

--- a/packages/bappo-components/src/components/Menu/StyledComponents.web.ts
+++ b/packages/bappo-components/src/components/Menu/StyledComponents.web.ts
@@ -1,49 +1,28 @@
+import styled from 'styled-components';
+
 import { DeviceKind } from '../../apis/DeviceKind';
-import { styled } from '../../apis/Style';
-import { breakpoint } from '../../internals/web/breakpoint';
+import { DivTouchableViewBase } from '../../internals/web/TouchableViewBase';
+import ScrollView from '../../primitives/ScrollView';
 import Text from '../../primitives/Text';
 import TouchableView from '../../primitives/TouchableView';
-import View from '../../primitives/View';
+import Icon from '../Icon';
 
 export const ActionRow = styled(TouchableView)`
   flex-direction: row;
   border-bottom: 1px solid #ddd;
   height: 40px;
   align-items: center;
-  padding-left: 8px;
   &:hover {
     background-color: #fafafa;
   }
 `;
 
-export const Label = styled(Text)`
-  padding-left: 4px;
-`;
+export const TriggerContainer = styled(DivTouchableViewBase)``;
 
-export const WebContainer = styled.div`
-  display: inline-block;
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-export const BackLink = styled(TouchableView)`
-  background-color: #eee;
-  flex-direction: row;
-  height: 40px;
-  align-items: center;
-  padding-left: 8px;
-  display: none;
-
-  @media (max-width: ${breakpoint.max}px) {
-    display: flex;
-  }
-`;
-
-export const PopoverContentContainer = styled(View)<{
-  $maxWidth?: any;
-  $minWidth?: any;
-  $maxHeight?: any;
+export const PopoverContentContainer = styled(ScrollView)<{
+  $maxWidth?: number;
+  $minWidth?: number;
+  $maxHeight?: number;
   $deviceKind: DeviceKind;
 }>`
   ${({ $deviceKind, $maxWidth, $minWidth, $maxHeight }) => {
@@ -55,13 +34,15 @@ export const PopoverContentContainer = styled(View)<{
       return `max-height: 50vh;`;
     }
   }}
-
-  overflow-y: scroll;
-  overflow-x: scroll;
 `;
 
-export const MenuItemLabel = styled(Label)`
-  flex-grow: 1;
-  flex-shrink: 1;
-  max-width: initial;
+export const MenuItemIcon = styled(Icon)`
+  margin-left: 8px;
+`;
+
+export const MenuItemLabel = styled(Text)<{
+  $hasIcon: boolean;
+}>`
+  padding-right: 8px;
+  ${({ $hasIcon }) => ($hasIcon ? '' : `padding-left: 8px;`)};
 `;

--- a/packages/bappo-components/src/components/Menu/__tests__/index.web.tsx
+++ b/packages/bappo-components/src/components/Menu/__tests__/index.web.tsx
@@ -3,31 +3,17 @@ import 'react-testing-library/cleanup-after-each';
 
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { getByText, render } from 'react-testing-library';
+import { render } from 'react-testing-library';
 
 import Menu from '..';
 
-const actions = [
-  {
-    icon: 'home',
-    label: 'menu1',
-    onPress: () => console.log('menu1 pressed'),
-  },
-  {
-    label: 'menu2',
-    onPress: () => console.log('menu2 pressed'),
-  },
-];
-
 test('should render a menu with two menu items', () => {
-  const { getByTestId, debug, container } = render(
+  const { getByTestId } = render(
     <Menu icon="cloud" testID="test">
-      <Menu.Item
-        icon="home"
-        label="menu1"
-        onPress={() => console.log('menu1 pressed')}
-      />
-      <Menu.Item label="menu2" onPress={() => console.log('menu2 pressed')} />
+      <Menu.Item icon="home" onPress={() => console.log('menu1 pressed')}>
+        menu1
+      </Menu.Item>
+      <Menu.Item onPress={() => console.log('menu2 pressed')}>menu2</Menu.Item>
     </Menu>,
   );
 
@@ -35,7 +21,7 @@ test('should render a menu with two menu items', () => {
   userEvent.click(getByTestId('test').querySelector('div')!);
 
   expect(getByTestId('overlay-container')).toMatchInlineSnapshot(`
-    .c7 {
+    .c9 {
       box-sizing: border-box;
       color: #191E26;
       display: inline;
@@ -56,50 +42,9 @@ test('should render a menu with two menu items', () => {
     }
 
     .c10 {
-      box-sizing: border-box;
-      color: #191E26;
-      display: inline;
-      -webkit-box-flex: 0;
-      -webkit-flex-grow: 0;
-      -ms-flex-positive: 0;
-      flex-grow: 0;
-      -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-      flex-shrink: 0;
-      font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
-      font-size: 14px;
-      position: relative;
-      white-space: pre-wrap;
-      word-wrap: break-word;
-      -ms-hyphens: auto;
-      cursor: inherit;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 100%;
-      white-space: nowrap;
-      display: -webkit-box;
-      -webkit-line-clamp: 1;
-      -webkit-box-orient: vertical;
-    }
-
-    .c8 {
       font-family: Material Icons;
       font-size: 16px;
       text-align: center;
-    }
-
-    .c9 {
-      -webkit-flex: none;
-      -ms-flex: none;
-      flex: none;
-      -webkit-align-items: center;
-      -webkit-box-align: center;
-      -ms-flex-align: center;
-      align-items: center;
-      height: 24px;
-      line-height: 24px;
-      width: 24px;
-      font-size: 16px;
     }
 
     .c0 {
@@ -130,7 +75,7 @@ test('should render a menu with two menu items', () => {
       min-width: 0;
     }
 
-    .c4 {
+    .c6 {
       -webkit-align-items: stretch;
       -webkit-box-align: stretch;
       -ms-flex-align: stretch;
@@ -158,7 +103,7 @@ test('should render a menu with two menu items', () => {
       min-width: 0;
     }
 
-    .c5 {
+    .c7 {
       -webkit-align-items: stretch;
       -webkit-box-align: stretch;
       -ms-flex-align: stretch;
@@ -193,7 +138,7 @@ test('should render a menu with two menu items', () => {
       cursor: pointer;
     }
 
-    .c5 * {
+    .c7 * {
       cursor: pointer;
     }
 
@@ -216,7 +161,23 @@ test('should render a menu with two menu items', () => {
       right: 0;
     }
 
-    .c6 {
+    .c3 {
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      overflow-x: hidden;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      -webkit-transform: translateZ(0);
+      -ms-transform: translateZ(0);
+      transform: translateZ(0);
+    }
+
+    .c5 {
+      min-height: 100%;
+    }
+
+    .c8 {
       -webkit-flex-direction: row;
       -ms-flex-direction: row;
       flex-direction: row;
@@ -226,29 +187,38 @@ test('should render a menu with two menu items', () => {
       -webkit-box-align: center;
       -ms-flex-align: center;
       align-items: center;
-      padding-left: 8px;
     }
 
-    .c6:hover {
+    .c8:hover {
       background-color: #fafafa;
     }
 
-    .c3 {
+    .c4 {
       max-height: 50vh;
-      overflow-y: scroll;
-      overflow-x: scroll;
     }
 
     .c11 {
-      padding-left: 4px;
-      -webkit-box-flex: 1;
-      -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
-      flex-grow: 1;
-      -webkit-flex-shrink: 1;
-      -ms-flex-negative: 1;
-      flex-shrink: 1;
-      max-width: initial;
+      -webkit-flex: none;
+      -ms-flex: none;
+      flex: none;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      height: 24px;
+      line-height: 24px;
+      width: 24px;
+      font-size: 16px;
+      margin-left: 8px;
+    }
+
+    .c12 {
+      padding-right: 8px;
+    }
+
+    .c13 {
+      padding-right: 8px;
+      padding-left: 8px;
     }
 
     <div
@@ -260,31 +230,35 @@ test('should render a menu with two menu items', () => {
         class="c0 c2"
       >
         <div
-          class="c0 c3"
+          class="c0 c3 c4"
         >
           <div
-            class="c4 c5 c6"
-            role="button"
-            tabindex="0"
+            class="c0 c5"
           >
             <div
-              class="c7 c8 c9"
-              data-text-as-pseudo-element=""
-            />
+              class="c6 c7 c8"
+              role="button"
+              tabindex="0"
+            >
+              <div
+                class="c9 c10 c11"
+                data-text-as-pseudo-element=""
+              />
+              <div
+                class="c9 c12"
+                data-text-as-pseudo-element="menu1"
+              />
+            </div>
             <div
-              class="c10 sc-AxmLO c11"
-              data-text-as-pseudo-element="menu1"
-            />
-          </div>
-          <div
-            class="c4 c5 c6"
-            role="button"
-            tabindex="0"
-          >
-            <div
-              class="c10 sc-AxmLO c11"
-              data-text-as-pseudo-element="menu2"
-            />
+              class="c6 c7 c8"
+              role="button"
+              tabindex="0"
+            >
+              <div
+                class="c9 c13"
+                data-text-as-pseudo-element="menu2"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/bappo-components/src/components/Menu/types.ts
+++ b/packages/bappo-components/src/components/Menu/types.ts
@@ -1,19 +1,15 @@
 export type MenuProps = {
+  children?: React.ReactNode;
   icon?: string;
-  children?: any;
   iconColor?: string;
   testID?: string;
   trigger?: React.ReactNode | ((isActive: boolean) => React.ReactNode);
-};
-
-export type MenuContext = {
-  close: () => void;
-  active: boolean;
+  triggerStyle?: React.CSSProperties;
 };
 
 export type MenuItemProps = {
-  label: string;
+  children?: React.ReactNode;
   icon?: string;
-  onPress: () => any;
   numberOfLines?: number;
+  onPress?: () => any;
 };

--- a/packages/bappo-components/src/components/Separator/__tests__/index.web.tsx
+++ b/packages/bappo-components/src/components/Separator/__tests__/index.web.tsx
@@ -8,7 +8,7 @@ test('should render a separator', () => {
 
   expect(getByTestId('test')).toMatchInlineSnapshot(`
     <div
-      class="sc-AxjAm hwdivQ Viewweb__StyledViewBase-io1hre-0 gXDTWH sc-AxirZ iSCPWa"
+      class="sc-AxjAm hwdivQ sc-AxirZ feQoIa sc-AxiKw jeqquu"
       data-testid="test"
     />
   `);

--- a/packages/bappo-components/src/components/Separator/__tests__/index.web.tsx
+++ b/packages/bappo-components/src/components/Separator/__tests__/index.web.tsx
@@ -1,3 +1,6 @@
+import 'jest-styled-components';
+import 'react-testing-library/cleanup-after-each';
+
 import React from 'react';
 import { render } from 'react-testing-library';
 
@@ -7,8 +10,43 @@ test('should render a separator', () => {
   const { getByTestId } = render(<Separator testID="test"></Separator>);
 
   expect(getByTestId('test')).toMatchInlineSnapshot(`
+    .c0 {
+      -webkit-align-items: stretch;
+      -webkit-box-align: stretch;
+      -ms-flex-align: stretch;
+      align-items: stretch;
+      border-color: #191E26;
+      border-style: solid;
+      border-width: 0;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-flex: 0;
+      -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+      flex-grow: 0;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
+      position: relative;
+      min-height: 0;
+      min-width: 0;
+    }
+
+    .c1 {
+      height: 1px;
+      margin-top: 8px;
+      margin-bottom: 8px;
+      background-color: rgba(0,0,0,0.12);
+    }
+
     <div
-      class="sc-AxjAm hwdivQ sc-AxirZ feQoIa sc-AxiKw jeqquu"
+      class="c0 c1"
       data-testid="test"
     />
   `);

--- a/packages/bappo-components/src/internals/Popover.web/index.tsx
+++ b/packages/bappo-components/src/internals/Popover.web/index.tsx
@@ -41,7 +41,7 @@ export function Popover({
   //    (opacity = 0)
   // 3. Effect runs and the style of the content container DOM element gets
   //    updated, making it visible in the right position
-  const [prevVisible, setPrevVisible] = React.useState(visible);
+  const [prevVisible, setPrevVisible] = React.useState(false);
   React.useEffect(() => {
     if (!prevVisible && visible) {
       updateContentContainerStyle();

--- a/packages/bappo-components/src/internals/Popover.web/types.ts
+++ b/packages/bappo-components/src/internals/Popover.web/types.ts
@@ -21,7 +21,7 @@ export type PopoverProps = {
    * edge of the popup aligns with the top edge of the anchor).
    */
   placement?: GetPopupPosition;
-  visible?: boolean;
+  visible: boolean;
 };
 
 export type GetPopupPosition = (

--- a/packages/bappo-components/storybook/storybook-native/storybook/stories/2-components/Menu/examples/example.js
+++ b/packages/bappo-components/storybook/storybook-native/storybook/stories/2-components/Menu/examples/example.js
@@ -4,13 +4,11 @@ import React from 'react';
 const MenuExample = () => (
   <View style={outerStyle}>
     <Menu minWidth={200}>
-      <Menu.Item
-        icon="home"
-        label="Home"
-        onPress={() => console.log('you pressed Home')}
-      />
+      <Menu.Item icon="home" onPress={() => console.log('you pressed Home')}>
+        Home
+      </Menu.Item>
       <HorizontalLine />
-      <Menu.Item label="Timer" onPress={() => alert('You pressed Timer')} />
+      <Menu.Item onPress={() => alert('You pressed Timer')}>Timer</Menu.Item>
     </Menu>
     <Menu
       trigger={
@@ -19,93 +17,70 @@ const MenuExample = () => (
         </View>
       }
     >
-      <Menu.Item
-        label="Action 1 - No Icon"
-        onPress={() => alert('You pressed Action 1 - No Icon')}
-      />
-      <Menu.Item
-        label="Action 2 - No Icon"
-        onPress={() => alert('You pressed Action 2 - No Icon')}
-      />
+      <Menu.Item onPress={() => alert('You pressed Action 1 - No Icon')}>
+        Action 1 - No Icon
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Action 2 - No Icon')}>
+        Action 2 - No Icon
+      </Menu.Item>
     </Menu>
     <Menu icon="cloud" align="right">
-      <Menu.Item
-        icon="home"
-        label="Home"
-        onPress={() => console.log('you pressed Home')}
-      />
-      <Menu.Item label="Timer" onPress={() => alert('You pressed Timer')} />
+      <Menu.Item icon="home" onPress={() => console.log('you pressed Home')}>
+        Home
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Timer')}>Timer</Menu.Item>
     </Menu>
     <Menu icon="menu">
-      <Menu.Item
-        icon="home"
-        label="Home"
-        onPress={() => console.log('you pressed Home')}
-      />
-      <Menu.Item label="Timer" onPress={() => alert('You pressed Timer')} />
+      <Menu.Item icon="home" onPress={() => console.log('you pressed Home')}>
+        Home
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Timer')}>Timer</Menu.Item>
     </Menu>
     <Menu icon="computer" iconColor="blue" maxWidth={100}>
-      <Menu.Item
-        icon="home"
-        label="Option1, this is 600px wide"
-        onPress={() => console.log('you pressed Home')}
-      />
-      <Menu.Item
-        icon="home"
-        label="Option2, this is 600px wide"
-        onPress={() => console.log('you pressed Timer')}
-      />
+      <Menu.Item icon="home" onPress={() => console.log('you pressed Home')}>
+        Option1, this is 600px wide
+      </Menu.Item>
+      <Menu.Item icon="home" onPress={() => console.log('you pressed Timer')}>
+        Option2, this is 600px wide
+      </Menu.Item>
     </Menu>
     <Menu icon="menu" align="left">
-      <Menu.Item
-        label="Action 1"
-        onPress={() => alert('You pressed Action 1')}
-      />
-      <Menu.Item
-        label="Action 2"
-        onPress={() => alert('You pressed Action 2')}
-      />
-      <Menu.Item
-        label="Action 3"
-        onPress={() => alert('You pressed Action 3')}
-      />
-      <Menu.Item
-        label="Action 4"
-        onPress={() => alert('You pressed Action 4')}
-      />
-      <Menu.Item
-        label="Action 5"
-        onPress={() => alert('You pressed Action 5')}
-      />
-      <Menu.Item
-        label="Action 6"
-        onPress={() => alert('You pressed Action 6')}
-      />
-      <Menu.Item
-        label="Action 7"
-        onPress={() => alert('You pressed Action 7')}
-      />
-      <Menu.Item
-        label="Action 8"
-        onPress={() => alert('You pressed Action 8')}
-      />
-      <Menu.Item
-        label="Action 9"
-        onPress={() => alert('You pressed Action 9')}
-      />
+      <Menu.Item onPress={() => alert('You pressed Action 1')}>
+        Action 1
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Action 2')}>
+        Action 2
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Action 3')}>
+        Action 3
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Action 4')}>
+        Action 4
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Action 5')}>
+        Action 5
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Action 6')}>
+        Action 6
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Action 7')}>
+        Action 7
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Action 8')}>
+        Action 8
+      </Menu.Item>
+      <Menu.Item onPress={() => alert('You pressed Action 9')}>
+        Action 9
+      </Menu.Item>
     </Menu>
 
     <Menu>
-      <Menu.Item
-        icon="home"
-        label="Option1"
-        onPress={() => console.log('you pressed Home')}
-      />
-      <Menu.Item
-        icon="home"
-        label="Option2"
-        onPress={() => console.log('you pressed Timer')}
-      />
+      <Menu.Item icon="home" onPress={() => console.log('you pressed Home')}>
+        Option1
+      </Menu.Item>
+      <Menu.Item icon="home" onPress={() => console.log('you pressed Timer')}>
+        Option2
+      </Menu.Item>
     </Menu>
   </View>
 );


### PR DESCRIPTION
This PR

1. Fixed problem that when `Menu` is rendered inside a modal, the `Menu` popup is sometimes behind the modal. The solution is `active ? <Popover visible /> : null` instead of `<Popover visible={active} />`.

1. Fixed problem that `Popover`'s content is not measured when using this pattern: `active ? <Popover visible /> : null`.

1. Kept only one container around the `Menu` trigger. It's not necessary to have two containers.

1. Allow `styled(Menu)` to style the `Menu` trigger container by passing down `className`.

1. Handle the case when `trigger` is a function `(isActive: boolean) => React.ReactNode`.

1. Change `label` prop on `Menu.Item` to `children` to allow custom content. Only when `children` is a string will it be wrapped with a `Text` component.

1. Removed back button on native and set `max-height` to half of the screen size to be consistent with web.

1. Fixed tests with missing `import 'jest-styled-components'`.