### PR TITLE
#1395 Modal form closes unexpectedly

### DIFF
--- a/packages/bappo-components/src/components/Modal/Modal.web/Modal.tsx
+++ b/packages/bappo-components/src/components/Modal/Modal.web/Modal.tsx
@@ -30,6 +30,11 @@ function Modal({
   const [modalContentLayout, setModalContentLayout] = React.useState<Layout>(
     null,
   );
+
+  const [mouseEntered, setMouseEntered] = React.useState(false);
+  const [mouseDown, setMouseDown] = React.useState(false);
+  const [cancelClose, setCancelClose] = React.useState(false);
+
   const modalContentContainerRef = React.useRef<HTMLDivElement>(null);
 
   const prevVisibleRef = React.useRef(visible);
@@ -62,7 +67,13 @@ function Modal({
   };
 
   return (
-    <Overlay onPress={onRequestClose} visible={visible}>
+    <Overlay
+      onPress={() => {
+        if (!cancelClose) onRequestClose();
+        setCancelClose(false);
+      }}
+      visible={visible}
+    >
       <ModalContentContainer
         $deviceKind={deviceKind}
         ref={modalContentContainerRef}
@@ -70,6 +81,20 @@ function Modal({
         onKeyDown={onModalContentKeyDown}
         onLayout={onModalContentLayout}
         $placement={placement}
+        onMouseEnter={(event: React.MouseEvent) => {
+          setMouseEntered(true);
+        }}
+        onMouseLeave={(event: React.MouseEvent) => {
+          setMouseEntered(false);
+          setCancelClose(mouseDown);
+        }}
+        onMouseUp={(event: React.MouseEvent) => {
+          setMouseDown(false);
+          setCancelClose(mouseEntered);
+        }}
+        onMouseDown={(event: React.MouseEvent) => {
+          setMouseDown(true);
+        }}
       >
         {/* There are three condition here
         1. Bydefault the header will not show as older application using previous version modal,


### PR DESCRIPTION
- Change the `onRequestClose` handler to not fire under the following conditions:
    - If the mouse pointer leaves the Modal dialog after a mouse down event, cancel the `onRequestClose` callback (dragging from inside the modal dialog to the overlay container)
    - If a mouse up event occurs after the mouse pointer enters the Modal dialog, cancel the `onRequestClose` callback (dragging from the overlay container to the inside of the modal dialog)