### PR TITLE
#1421 Modal Form header title text clipping

### DIFF
--- a/packages/bappo-components/src/components/ModalForm/FormBody/FormBody.web.tsx
+++ b/packages/bappo-components/src/components/ModalForm/FormBody/FormBody.web.tsx
@@ -122,7 +122,6 @@ const ModalFormTitleText = styled(Text).attrs((props) => ({
 }>`
   font-size: 20px;
   color: #2b2826;
-  line-height: 20px;
 
   ${(props) =>
     props.$deviceKind === 'phone' || props.$deviceKind === 'large-phone'

--- a/packages/bappo-components/src/components/ModalForm/StyledComponents.js
+++ b/packages/bappo-components/src/components/ModalForm/StyledComponents.js
@@ -26,7 +26,6 @@ export const ModalFormTitleContainer = styled(View)`
 export const modalFormMobileTitleTextStyle = css`
   font-size: 16px;
   color: #2b2826;
-  line-height: 16px;
   text-align: center;
 `;
 


### PR DESCRIPTION
- Removed line-height style from the header title text so that clipping of descending characters do not occur (the parent div's overflow is set to hidden to allow the display of ellipsis when the title is more than 2 lines of text but this will clip the descending characters on the last line if the line height is the same as the font size).