### PR TITLE
Fix 1426 icon selector crashes in form and improve performance

### DIFF
--- a/packages/bappo-components/src/components/IconSelector/IconModal/IconList.tsx
+++ b/packages/bappo-components/src/components/IconSelector/IconModal/IconList.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import FlatList from '../../../primitives/FlatList';
+import View from '../../../primitives/View';
+import IconButton from '../../IconButton';
+
+const NUMBER_OF_COLUMNS = 23;
+
+export function IconList({
+  onSelect,
+  selectedIcons,
+}: {
+  onSelect: (selectedIcon: string) => void;
+  selectedIcons: string[];
+}) {
+  return (
+    <StyledFlatList
+      data={selectedIcons}
+      initialNumToRender={6 * NUMBER_OF_COLUMNS}
+      keyExtractor={(icon: string) => icon}
+      numColumns={NUMBER_OF_COLUMNS}
+      renderItem={({ item: icon }: { item: string }) => (
+        <FlatListRow>
+          <IconButton
+            key={icon}
+            name={icon}
+            onPress={() => onSelect(icon)}
+            tooltip={icon}
+          />
+        </FlatListRow>
+      )}
+    />
+  );
+}
+
+const StyledFlatList = styled(FlatList)`
+  flex: none;
+  height: 145px;
+`;
+
+const FlatListRow = styled(View)`
+  flex-direction: row;
+`;

--- a/packages/bappo-components/src/components/IconSelector/IconModal/IconModal.web.tsx
+++ b/packages/bappo-components/src/components/IconSelector/IconModal/IconModal.web.tsx
@@ -1,13 +1,12 @@
-import chunk from 'lodash/chunk';
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import MateriIcon from '../../../../glyphmaps/MaterialIcons.json';
-import TextField from '../../../components/input-fields/TextField';
-import FlatList from '../../../primitives/FlatList';
+import { useDebouncedInputProps } from '../../../internals/hooks/useDebouncedInputProps';
 import View from '../../../primitives/View';
-import IconButton from '../../IconButton';
+import TextField from '../../input-fields/TextField';
 import Modal from '../../Modal';
+import { IconList } from './IconList';
 
 interface IconModalProps {
   modalVisable: boolean;
@@ -22,17 +21,17 @@ const IconModal: React.FC<IconModalProps> = ({
   setModalVisable,
   setIconName,
 }) => {
-  const ARRAY_SIZE = 23;
   const [input, setInput] = useState('');
-  // filter the list and generate 2D array for flatList
-  const resultArray = useMemo(
-    () =>
-      chunk(
-        iconList.filter((icon) => (input ? icon.includes(input) : true)),
-        ARRAY_SIZE,
-      ),
+
+  const selectedIcons = useMemo(
+    () => iconList.filter((icon) => (input ? icon.includes(input) : true)),
     [input],
   );
+
+  const textFieldProps = useDebouncedInputProps({
+    onValueChange: setInput,
+    value: input,
+  });
 
   return (
     <Modal
@@ -42,34 +41,17 @@ const IconModal: React.FC<IconModalProps> = ({
     >
       <IconsContainer>
         <TextField
-          value={input}
-          onValueChange={setInput}
+          {...textFieldProps}
           placeholder="Type to search Icon"
           reserveErrorSpace={false}
         />
-        <FlatListContainer>
-          <FlatList
-            horizontal={false}
-            data={resultArray}
-            renderItem={({ item }: { item: string[] }) => (
-              <FlatListRow key={item[0]}>
-                {item.map((icon: string) => {
-                  return (
-                    <IconButton
-                      key={icon}
-                      name={icon}
-                      onPress={() => {
-                        setIconName(icon);
-                        setModalVisable(false);
-                      }}
-                      tooltip={icon}
-                    />
-                  );
-                })}
-              </FlatListRow>
-            )}
-          />
-        </FlatListContainer>
+        <IconList
+          onSelect={(icon: string) => {
+            setIconName(icon);
+            setModalVisable(false);
+          }}
+          selectedIcons={selectedIcons}
+        />
       </IconsContainer>
     </Modal>
   );
@@ -77,15 +59,6 @@ const IconModal: React.FC<IconModalProps> = ({
 
 const IconsContainer = styled(View)`
   padding: 0px 8px;
-`;
-
-const FlatListContainer = styled(View)`
-  align-items: center;
-  height: 145px;
-`;
-
-const FlatListRow = styled(View)`
-  flex-direction: row;
 `;
 
 export default IconModal;

--- a/packages/bappo-components/src/components/IconSelector/IconSelector.tsx
+++ b/packages/bappo-components/src/components/IconSelector/IconSelector.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
 import IconButton from '../../components/IconButton';
-import View from '../../primitives/View';
 import { IconProps } from '../Icon/Icon';
 import IconModal from './IconModal';
 
@@ -18,7 +17,7 @@ const IconSelector: React.FC<IconSelectorProps> = ({
 }) => {
   const [modalVisable, setModalVisable] = useState(false);
   return (
-    <View>
+    <React.Fragment>
       <IconButton
         name={value}
         onPress={() => {
@@ -34,7 +33,7 @@ const IconSelector: React.FC<IconSelectorProps> = ({
           setIconName={onValueChange}
         />
       ) : null}
-    </View>
+    </React.Fragment>
   );
 };
 

--- a/packages/bappo-components/src/internals/hooks/useDebouncedInputProps.ts
+++ b/packages/bappo-components/src/internals/hooks/useDebouncedInputProps.ts
@@ -1,0 +1,41 @@
+import debounce from 'lodash/debounce';
+import React from 'react';
+
+export function useDebouncedInputProps({
+  onValueChange,
+  value,
+}: {
+  onValueChange?: (value: string) => void;
+  value?: string;
+}) {
+  const [rawInput, setRawInput] = React.useState(value);
+  const [prevValue, setPrevValue] = React.useState(value);
+
+  // Sync input with passed-in value in case it was modified from outside
+  if (value !== prevValue) {
+    if (value !== rawInput) {
+      setRawInput(value);
+    }
+    setPrevValue(value);
+  }
+
+  const debouncedOnValueChange = React.useMemo(() => {
+    return onValueChange && debounce(onValueChange, 500);
+  }, [onValueChange]);
+  // clear timeout
+  React.useEffect(() => {
+    return () => {
+      if (debouncedOnValueChange) {
+        debouncedOnValueChange.cancel();
+      }
+    };
+  }, [debouncedOnValueChange]);
+
+  return {
+    onValueChange: (newValue: string) => {
+      setRawInput(newValue);
+      debouncedOnValueChange?.(newValue);
+    },
+    value: rawInput,
+  };
+}

--- a/packages/bappo-components/src/primitives/Form/useFieldState.ts
+++ b/packages/bappo-components/src/primitives/Form/useFieldState.ts
@@ -1,6 +1,6 @@
-import invariant from 'invariant';
 import { isEqual } from 'lodash';
 import React from 'react';
+import warning from 'warning';
 
 import { useFormState } from './FormState/Context';
 import { FieldState, FieldValidator } from './FormState/types';
@@ -43,12 +43,15 @@ export function useFieldState<V>(
   const formState = useFormState();
   const mode = fieldState
     ? 'controlled'
-    : formState
+    : formState && name
     ? 'form-field'
     : 'standalone';
 
   /* Begin form field mode */
-  invariant(!(mode === 'form-field' && !name), `prop "name" is required.`);
+  warning(
+    !(formState && !name),
+    `Field is inside a form but is regarded as a standalone field as it doesn't have the "name" prop.`,
+  );
   // register validators with form
   React.useEffect(() => {
     if (mode === 'form-field' && formState && name && validate) {


### PR DESCRIPTION
This PR

1. Fixes crash when `IconSelector` is inside a `Form` or a `ModalForm`. The crash is because the `TextField` for searching icons detects that it's inside a form context and tries to connect to it which requires the "name" prop to be configured. In this case we actually want the field to be standalone (the form should be be aware of it). So I changed the logic so that if a field inside a form does not have the "name" prop configured, it will not connect to the form and it will work in standalone mode.

1. Adds debouncing to the search input to avoid jank. You may notice that it's still quite janky if you run the storybook locally which uses dev versions of npm packages. It should be fine in production.